### PR TITLE
회원가입 재작업, 이메일 재발송 추가

### DIFF
--- a/src/app/(auth)/signup/email-check/page.tsx
+++ b/src/app/(auth)/signup/email-check/page.tsx
@@ -1,0 +1,5 @@
+import Emailsend from '@/pages/emailsend';
+
+export default function page() {
+  return <Emailsend />;
+}

--- a/src/app/(auth)/signup/success/page.tsx
+++ b/src/app/(auth)/signup/success/page.tsx
@@ -1,5 +1,5 @@
-import Emailsend from '@/pages/emailsend';
+import SignupPreferences from '@/pages/SignupPreferences';
 
 export default function page() {
-  return <Emailsend />;
+  return <SignupPreferences />;
 }

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -110,7 +110,7 @@ export default function Signup() {
         })
         .then((data) => {
           console.log(data.data);
-          router.push('/signup/success');
+          router.push('/signup/email-check');
         })
         .catch((error) => {
           console.log(error.response.data);

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -8,6 +8,7 @@ import Checkbox from '@/components/common/Checkbox';
 import { FormEvent, useEffect, useState } from 'react';
 import axios from 'axios';
 import { useRouter } from 'next/navigation';
+import { useSignupStore } from '@/stores/signupStore';
 
 type NewUserData = {
   email: string;
@@ -38,7 +39,8 @@ export default function Signup() {
   const [invalidAddress, setInvalidAddress] = useState(false);
   const [invalidBirthDate, setInvalidBirthDate] = useState(false);
 
-  const [newUser, setNewUser] = useState<NewUserData>();
+  // const [newUser, setNewUser] = useState<NewUserData>();
+  const { userData, setData } = useSignupStore();
   const router = useRouter();
 
   const nicknameCheck = /^[가-힣a-zA-Z0-9]{2,10}$/;
@@ -85,7 +87,7 @@ export default function Signup() {
       if (!duplicationCheck) alert('닉네임 중복 체크해주세요.');
       else alert('회원가입에 실패했습니다.');
     } else {
-      setNewUser({
+      setData({
         email: email,
         password: password,
         confirmPassword: confirmPassword,
@@ -99,9 +101,9 @@ export default function Signup() {
   };
 
   useEffect(() => {
-    if (newUser && newUser.email.length > 0) {
+    if (userData) {
       axios
-        .post('http://funfun.cloud/api/users/signup', newUser, {
+        .post('http://funfun.cloud/api/users/signup', userData, {
           headers: {
             'Content-Type': 'application/json',
           },
@@ -115,7 +117,7 @@ export default function Signup() {
           alert(error.response.data.message);
         });
     }
-  }, [newUser]);
+  }, [userData]);
 
   return (
     <form

--- a/src/pages/emailsend.tsx
+++ b/src/pages/emailsend.tsx
@@ -1,11 +1,43 @@
-// "use client";
+'use client';
 import Image from 'next/image';
 import EmailImage from '@/assets/images/email.svg';
+import { FormEvent } from 'react';
+import axios from 'axios';
+import { useSignupStore } from '@/stores/signupStore';
 
 export default function Emailsend() {
+  const { userData } = useSignupStore();
+
+  const emailSendAgain = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (userData) {
+      axios
+        .post(
+          `http://funfun.cloud/api/users/send/signup/${userData.email}`,
+          userData.email,
+          {
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          },
+        )
+        .then((response) => {
+          console.log(response.data);
+          alert('인증 메일이 재발송되었습니다.');
+        })
+        .catch((error) => {
+          console.log(error.response.data);
+          alert(error.response.data.message);
+        });
+    }
+  };
+
   return (
     <div className="flex min-h-screen flex-col items-center justify-start bg-[#232323] px-6 pt-[140px] text-center text-white md:justify-center md:pt-0">
-      <div className="flex w-full max-w-[620px] flex-col items-center">
+      <form
+        onSubmit={emailSendAgain}
+        className="flex w-full max-w-[620px] flex-col items-center"
+      >
         <div className="mb-6">
           <Image src={EmailImage} alt="email icon" width={200} height={200} />
         </div>
@@ -23,7 +55,7 @@ export default function Emailsend() {
         <button className="mt-6 mb-12 h-12 w-full max-w-[510px] rounded-md bg-[#313131] text-base font-bold text-[#bdbdbd] md:h-16">
           인증 메일 재발송
         </button>
-      </div>
+      </form>
     </div>
   );
 }

--- a/src/stores/signupStore.ts
+++ b/src/stores/signupStore.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand';
+
+type NewUserData = {
+  email: string;
+  password: string;
+  confirmPassword: string;
+  nickname: string;
+  address: string;
+  birthDate: string;
+  gender: 'MALE' | 'FEMALE';
+  isMarketingAgreed: boolean;
+};
+
+interface SignupStore {
+  userData: NewUserData | null;
+  code: string;
+  setData: (data: NewUserData) => void;
+  clearData: () => void;
+  setCode: (code: string) => void;
+  clearCode: () => void;
+  clearAll: () => void;
+}
+
+export const useSignupStore = create<SignupStore>((set) => ({
+  userData: null,
+  code: '',
+  setData: (data) => set({ userData: data }),
+  clearData: () => set({ userData: null }),
+  setCode: (code) => set({ code: code }),
+  clearCode: () => set({ code: '' }),
+  clearAll: () => set({ userData: null, code: '' }),
+}));


### PR DESCRIPTION
## PR 개요

회원가입 재작업, 이메일 재발송 추가

---

## 작성 상세 내용

이번 PR에서 수행한 작업 유형에 체크해 주세요.

- [X] New Feature (새 기능 추가)
- [ ] Bug Fix (버그 수정)
- [ ] Remove Feature (기능 제거)
- [X] Change Logic (로직 수정)
- [ ] Style (스타일 수정:코드 포맷, css 등)
- [ ] Test (테스트 코드 추가/수정)
- [X] Set up (환경 설정, 패키지 설정 등)

---

## 작업 내용 관련 이슈

* 라우터 구조가 변경됨에 따라 코드를 리팩토링했습니다.
* 회원가입 2단계 페이지에서 이메일 재발송 버튼을 클릭하면 인증 이메일이 재발송 됩니다.
   3분에 한번씩 가능하며, 그보다 빠르게 클릭하면 에러 메시지를 출력합니다.
* zustand를 사용하여 회원가입 시 유저 정보를 저장하여 이용합니다.
   회원가입이 다 끝나면 초기화되도록 할 계획입니다.

---

## 새로 설치한 패키지 목록

X

---

## 스크린샷(선택)

UI 변경사항이 있다면 스크린샷을 첨부합니다.

---

## 리뷰 시 참고 사항

리뷰어가 알면 좋은 사항이나 특이사항을 작성합니다.

---